### PR TITLE
Add context menu action to play current selection

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 // Add action to context menu
 chrome.contextMenus.create({
     id: "play-action",
-    title: "Splia",
+    title: "Lesa upp valinn texta",
     contexts: ["selection"],
   },
 );

--- a/background.js
+++ b/background.js
@@ -9,7 +9,10 @@ chrome.contextMenus.create({
 // Handler for centext menu
 const onClick = (info, tab) => {
   if (info.menuItemId == "play-action") {
-    chrome.tabs.sendMessage(tab.id, {action: "play"});
+    chrome.tabs.sendMessage(tab.id, {
+      receiver: "content_script",
+      command: "play",
+    });
   }
 }
 chrome.contextMenus.onClicked.addListener(onClick);

--- a/background.js
+++ b/background.js
@@ -1,0 +1,16 @@
+// Add action to context menu
+chrome.contextMenus.create({
+    id: "play-action",
+    title: "Splia",
+    contexts: ["selection"],
+  },
+);
+
+// Handler for centext menu
+const onClick = (info, tab) => {
+  if (info.menuItemId == "play-action") {
+    chrome.tabs.sendMessage(tab.id, {action: "play"});
+  }
+}
+chrome.contextMenus.onClicked.addListener(onClick);
+

--- a/content/content.js
+++ b/content/content.js
@@ -164,12 +164,3 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   messageHandler(message).then(sendResponse);
   return true;
 });
-
-/**
- * Recieve messages
- */
-chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-  if (request.action === "play") {
-    play();
-  }
-});

--- a/content/content.js
+++ b/content/content.js
@@ -164,3 +164,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   messageHandler(message).then(sendResponse);
   return true;
 });
+
+/**
+ * Recieve messages
+ */
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+  if (request.action === "play") {
+    play();
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -10,10 +10,14 @@
     "32": "icons/favicon-32x32.png"
   },
 
-  "permissions": ["activeTab"],
+  "permissions": ["activeTab", "contextMenus"],
 
   "action": {
     "default_popup": "popup/popup.html"
+  },
+
+  "background": {
+    "service_worker": "background.js"
   },
 
   "content_scripts": [


### PR DESCRIPTION
Added a context menu action to play the current selection.

It is not possible to create a context menu item in a "content" so I needed to add a background script that runs once on startup.
It sends a message to the correct tab and "presses" play. The play function already plays the selected text if there is a text selected so that is all.